### PR TITLE
the baseurl was added to product links for product detail pages.

### DIFF
--- a/_includes/product-styles.html
+++ b/_includes/product-styles.html
@@ -1,7 +1,7 @@
 <div class="styles">
 	{% for style in include.product.styles %}
 		<div class="style" data-item-id="{{ forloop.index }}" {% unless forloop.first %}style="display: none"{% endunless %}>
-			<a href="{{ include.product.url }}">
+			<a href="{{ site.baseurl }}{{ include.product.url }}">
 				<img src="{{ site.baseurl }}{{ style.image }}">
 			</a>
 		</div>


### PR DESCRIPTION
The baseurl was added to product links for product detail pages. Thank to that, baseurl functionality are enabled for product pages.